### PR TITLE
 Preparing for lua-resty-openidc ~> 1.7.1-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You also need to set the `KONG_CUSTOM_PLUGINS` environment variable
 | `config.client_id` || true | OIDC Client ID |
 | `config.client_secret` || true | OIDC Client secret |
 | `config.discovery` | https://.well-known/openid-configuration | false | OIDC Discovery Endpoint (`/.well-known/openid-configuration`) |
-| `config.scope` | oidc | false| OAuth2 Token scope. To use OIDC it has to contains the `oidc` scope |
+| `config.scope` | openid | false| OAuth2 Token scope. To use OIDC it has to contains the `openid` scope |
 | `config.ssl_verify` | false | false | Enable SSL verification to OIDC Provider |
 | `config.session_secret` | | false | Additional parameter, which is used to encrypt the session cookie. Needs to be random |
 | `config.introspection_endpoint` | | false | Token introspection endpoint |

--- a/README.md
+++ b/README.md
@@ -59,9 +59,13 @@ If you're using `luarocks` execute the following:
 
      luarocks install kong-oidc
 
-You also need to set the `KONG_CUSTOM_PLUGINS` environment variable
+[Kong < 0.14] You also need to set the `KONG_CUSTOM_PLUGINS` environment variable
 
      export KONG_CUSTOM_PLUGINS=oidc
+
+[Kong >= 0.14] Since `KONG_CUSTOM_PLUGINS` has been removed, you also need to set the `KONG_PLUGINS` environment variable to include besides the bundled ones, oidc
+
+     export KONG_PLUGINS=bundled,oidc
      
 ## Usage
 

--- a/kong-oidc-1.1.0-0.rockspec
+++ b/kong-oidc-1.1.0-0.rockspec
@@ -1,8 +1,8 @@
 package = "kong-oidc"
 version = "1.1.0-0"
 source = {
-    url = "git://github.com/nokia/kong-oidc",
-    tag = "v1.1.0",
+    url = "git://github.com/Revomatico/kong-oidc",
+    tag = "master",
     dir = "kong-oidc"
 }
 description = {
@@ -22,7 +22,7 @@ description = {
     license = "Apache 2.0"
 }
 dependencies = {
-    "lua-resty-openidc ~> 1.6.0"
+    "lua-resty-openidc ~> 1.7.1-1"
 }
 build = {
     type = "builtin",

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -12,7 +12,7 @@ local function parseFilters(csvFilters)
   return filters
 end
 
-function M.get_redirect_uri_path(ngx)
+function M.get_redirect_uri(ngx)
   local function drop_query()
     local uri = ngx.var.request_uri
     local x = uri:find("?")
@@ -49,7 +49,7 @@ function M.get_options(config, ngx)
     introspection_endpoint_auth_method = config.introspection_endpoint_auth_method,
     bearer_only = config.bearer_only,
     realm = config.realm,
-    redirect_uri_path = config.redirect_uri_path or M.get_redirect_uri_path(ngx),
+    redirect_uri = config.redirect_uri or M.get_redirect_uri(ngx),
     scope = config.scope,
     response_type = config.response_type,
     ssl_verify = config.ssl_verify,


### PR DESCRIPTION
`kong-oidc-1.1.0-0.rockspec` should be changed back to point to `git://github.com/larsw/kong-oidc`, and ultimately, if PR goes back - to nokia.