### PR TITLE
Use local scope for token variable

### DIFF
--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -81,7 +81,7 @@ end
 
 function M.injectAccessToken(accessToken, headerName, bearerToken)
   ngx.log(ngx.DEBUG, "Injecting " .. headerName)
-  token = accessToken
+  local token = accessToken
   if (bearerToken) then
     token = formatAsBearerToken(token)
   end


### PR DESCRIPTION
Otherwise lua would emit warnings